### PR TITLE
Add site_id option for collecting metrics from a non-default site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Add `site_id` option for collecting metrics from a non-default site
 
 ## [1.0.0] - 2016-10-21
 

--- a/bin/metrics-unifi.rb
+++ b/bin/metrics-unifi.rb
@@ -44,13 +44,13 @@ class UnifiMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: "#{Socket.gethostname}.unifi"
 
   option :controller,
-         description: 'Unifi AP controller hostname',
+         description: 'Unifi AP controller hostname (default: unifi)',
          short: '-c HOSTNAME',
          long: '--controller HOSTNAME',
          default: 'unifi'
 
   option :username,
-         description: 'Username',
+         description: 'Username (default: admin)',
          short: '-u USERNAME',
          long: '--username USERNAME',
          default: 'admin'
@@ -62,19 +62,19 @@ class UnifiMetrics < Sensu::Plugin::Metric::CLI::Graphite
          required: true
 
   option :port,
-         description: 'Port',
+         description: 'Port (default: 8443)',
          short: '-P PORT',
          long: '--port PORT',
          default: 8443
 
   option :unifi_version,
-         description: 'Unifi API version',
+         description: 'Unifi API version (default: v4)',
          short: '-V VERSION',
          long: '--unifi-version VERSION',
          default: 'v4'
 
   option :site_id,
-         description: 'Site ID',
+         description: 'Site ID (default: default)',
          short: '-S SITE ID',
          long: '--site-id SITE ID',
          default: 'default'

--- a/bin/metrics-unifi.rb
+++ b/bin/metrics-unifi.rb
@@ -15,10 +15,15 @@
 #   gem: sensu-plugin
 #
 # USAGE:
+#   collect metrics from the default site:
 #   metrics-unifi.rb -c unifi.int.mycompany.co -u admin -p unifipassword
 #
-# NOTES:
+#   collect metrics from site 'mywifi':
+#   metrics-unifi.rb -c unifi.int.mycompany.co -u admin -p unifipassword -S mywifi
 #
+# NOTES:
+#   Specify the site ID if using a non-default site. The site ID can be obtained from the
+#   web UI e.g. /manage/s/<site>/dashboard
 #
 # LICENSE:
 #   Copyright Eric Heydrick <eheydrick@gmail.com>
@@ -68,8 +73,14 @@ class UnifiMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--unifi-version VERSION',
          default: 'v4'
 
+  option :site_id,
+         description: 'Site ID',
+         short: '-S SITE ID',
+         long: '--site-id SITE ID',
+         default: 'default'
+
   def unifi_stats
-    unifi = Unifi::Api::Controller.new(config[:controller], config[:username], config[:password], config[:port], config[:unifi_version])
+    unifi = Unifi::Api::Controller.new(config[:controller], config[:username], config[:password], config[:port], config[:unifi_version], config[:site_id])
     aps = unifi.get_aps
 
     metrics = Hash.new(0)


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

This allows passing the site id when you need to monitor a non-default site.
#### Known Compatablity Issues

None
